### PR TITLE
tests: Fix e2e-tests by renaming wasm file to new policy name

### DIFF
--- a/e2e.bats
+++ b/e2e.bats
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 
 @test "RunAsAny should accept empty runAsUser, runAsGroup and supplementalGroups" {
-	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_run_as_any.json target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_run_as_any.json target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
  }
 
 @test "MustRunAs should reject invalid user ID" {
-	run kwctl run  --request-path test_data/e2e/invalid_user_id.json  --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/invalid_user_id.json  --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
@@ -16,7 +16,7 @@
  }
 
 @test "MustRunAs should reject invalid group ID" {
-	run kwctl run  --request-path test_data/e2e/invalid_group_id.json  --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/invalid_group_id.json  --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
@@ -24,7 +24,7 @@
  }
 
 @test "MustRunAs should reject invalid supplemental group ID" {
-	run kwctl run  --request-path test_data/e2e/invalid_supplemental_group_.json  --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/invalid_supplemental_group_.json  --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
@@ -32,7 +32,7 @@
  }
 
 @test "MustRunAs should patch empty runAsUser, runAsGroup and supplementalGroups" {
-	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_must_run_as.json  target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
@@ -40,14 +40,14 @@
  }
 
 @test "MayRunAs should accept empty runAsGroup and supplementalGroups" {
-	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_may_run_as.json target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_may_run_as.json target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
  }
 
 @test "MayRunAs should reject invalid group ID" {
-	run kwctl run  --request-path test_data/e2e/invalid_group_id.json  --settings-path test_data/e2e/settings_may_run_as.json  target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/invalid_group_id.json  --settings-path test_data/e2e/settings_may_run_as.json  target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
@@ -55,7 +55,7 @@
  }
 
 @test "MayRunAs should reject invalid supplemental group ID" {
-	run kwctl run  --request-path test_data/e2e/invalid_supplemental_group_.json  --settings-path test_data/e2e/settings_may_run_as.json  target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/invalid_supplemental_group_.json  --settings-path test_data/e2e/settings_may_run_as.json  target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
@@ -63,14 +63,14 @@
  }
 
 @test "MustRunAs should accept valid runAsUser, runAsGroup and supplementalGroups" {
-	run kwctl run  --request-path test_data/e2e/valid_security_context.json --settings-path test_data/e2e/settings_must_run_as.json target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/valid_security_context.json --settings-path test_data/e2e/settings_must_run_as.json target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
 }
 
 @test "MustRunAsNonRoot should reject 0 as user ID" {
-	run kwctl run  --request-path test_data/e2e/zero_as_user_id.json --settings-path test_data/e2e/settings_must_run_as_non_root.json target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/zero_as_user_id.json --settings-path test_data/e2e/settings_must_run_as_non_root.json target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
@@ -78,7 +78,7 @@
 }
 
 @test "MustRunAsNonRoot should mutate request when runAsUser is not defined" {
-	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_must_run_as_non_root.json target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/empty_security_context_pod.json --settings-path test_data/e2e/settings_must_run_as_non_root.json target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
@@ -86,7 +86,7 @@
 }
 
 @test "MustRunAsNonRoot should accept request when user defined is not root" {
-	run kwctl run  --request-path test_data/e2e/valid_security_context.json --settings-path test_data/e2e/settings_must_run_as_non_root.json target/wasm32-unknown-unknown/release/psp_user_group.wasm
+	run kwctl run  --request-path test_data/e2e/valid_security_context.json --settings-path test_data/e2e/settings_must_run_as_non_root.json target/wasm32-unknown-unknown/release/user_group_psp.wasm
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]


### PR DESCRIPTION
Test locally, they pass (note: they aren't run in CI).

Last part of https://github.com/kubewarden/user-group-psp-policy/issues/4.