### PR TITLE
fix: Default all `rule` to `RunAsAny` if not set

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,7 +11,7 @@ pub(crate) struct IDRange {
     pub max: i64,
 }
 
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 pub(crate) struct RuleStrategy {
     pub rule: String,
@@ -25,6 +25,14 @@ impl RuleStrategy {
             }
         }
         false
+    }
+}
+impl Default for RuleStrategy {
+    fn default() -> Self {
+        RuleStrategy {
+            rule: "RunAsAny".to_string(),
+            ranges: vec![],
+        }
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fixes https://github.com/kubewarden/user-group-psp-policy/issues/12 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

`cargo test` passing.

Also, one can instantiate the following policy built from this branch:
```apiVersion: policies.kubewarden.io/v1alpha2
kind: ClusterAdmissionPolicy
metadata:
  name: supplementalgroups
spec:
  policyServer: default
  module: registry://ghcr.io/viccuad/user-group-psp-policy:defaults
  rules:
  - apiGroups: [""]
    apiVersions: ["v1"]
    resources: ["pods"]
    operations:
    - CREATE
    - UPDATE
  mutating: false
  settings:
    run_as_user:
      rule: "RunAsAny"
    # run_as_group:
    #   rule: "RunAsAny"
    supplemental_groups:
      rule: "MustRunAs"
      ranges:
        - min: 100
          max: 200
```

Which correctly rejects:
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-supplementalgroups-disallowed
  labels:
    app: nginx-users
spec:
  securityContext:
    supplementalGroups:
      - 250
  containers:
    - name: nginx
      image: nginx

```

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Another option is to move `RuleStrategy.rule` to enums, instead of strings.


