### PR TITLE
Allow overwrite user and groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ spec:
   settings:
     run_as_user:
       rule: "MustRunAs"
+      overwrite: false
       ranges:
         - min: 1000
           max: 2000
@@ -55,7 +56,7 @@ The policy has three settings:
 
 All three settings have no defaults, just like the deprecated PSP (also, they would get used if `mutating` is `true`).
 
-All three settings are JSON objects composed by two attributes: `rule` and `ranges`. The `rule` attribute defines
+All three settings are JSON objects composed by three attributes: `rule`, `ranges` and `overwrite`. The `rule` attribute defines
 the strategy used by the policy to enforce users and groups used in containers. The available strategies are:
 
 * `run_as_user`:
@@ -72,6 +73,9 @@ the strategy used by the policy to enforce users and groups used in containers. 
 	* `RunAsAny` - No default provided. Allows any `supplementalGroups` to be specified
 
 The `ranges` is a list of JSON objects with two attributes: `min` and `max`. Each range object define the user/group ID range used by the rule.
+
+`overwrite` attribute can be set `true` only with the rule `MustRunAs`. This flag configure the policy to mutate the `runAsUser` or `runAsGroup` despite of the value present in the
+request. Even if the value is a valid one. The default value of this attribute is `false`.
 
 ### Examples
 
@@ -184,6 +188,44 @@ To enforce a group when the container has some group defined
         "min": 2001,
         "max": 3000
       }
+    ]
+  }
+}
+```
+
+To enforce that user and groups will be the defined one in the policy configuration,
+set `overwrite` as `true`:
+
+```json
+{
+  "run_as_user": {
+    "rule": "MustRunAs",
+    "overwrite": true,
+    "ranges": [
+      {
+        "min": 1000,
+        "max": 1999
+      }
+    ]
+  },
+  "run_as_group": {
+    "rule": "MustRunAs",
+    "overwrite": true,
+    "ranges": [
+      {
+        "min": 1000,
+        "max": 1999
+      },
+    ]
+  },
+  "supplemental_groups":{
+    "rule": "MustRunAs",
+    "overwrite": true,
+    "ranges": [
+      {
+        "min": 1000,
+        "max": 1999
+      },
     ]
   }
 }

--- a/e2e.bats
+++ b/e2e.bats
@@ -91,3 +91,11 @@
 	echo "$output"
 	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
 }
+
+@test "MustRunAs should patch runAsUser, runAsGroup and supplementalGroups when 'overwrite' is true" {
+	run kwctl run  --request-path test_data/e2e/valid_security_context.json --settings-path test_data/e2e/settings_must_run_as_overwrite.json annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+	[ $(expr "$output" : '.*"patchType":"JSONPatch".*') -ne 0 ]
+ }

--- a/test_data/e2e/settings_must_run_as_overwrite.json
+++ b/test_data/e2e/settings_must_run_as_overwrite.json
@@ -1,0 +1,44 @@
+{
+  "run_as_user": {
+    "rule": "MustRunAs",
+    "overwrite": true,
+    "ranges": [
+      {
+        "min": 1000,
+        "max": 2000
+      },
+      {
+        "min": 2001,
+        "max": 3000
+      }
+    ]
+  },
+  "run_as_group": {
+    "rule": "MustRunAs",
+    "overwrite": true,
+    "ranges": [
+      {
+        "min": 1000,
+        "max": 2000
+      },
+      {
+        "min": 2001,
+        "max": 3000
+      }
+    ]
+  },
+  "supplemental_groups": {
+    "rule": "MustRunAs",
+    "overwrite": true,
+    "ranges": [
+      {
+        "min": 1000,
+        "max": 2000
+      },
+      {
+        "min": 2001,
+        "max": 3000
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds a new policy configuration that allow the user overwrite the value defined in the request. The overwrite if replace the user and groups in the request regardless of what is defined.

Fix #3 

## Test

```bash
kubectl apply -f  - <<EOF
apiVersion: policies.kubewarden.io/v1alpha2
kind: ClusterAdmissionPolicy
metadata:
  name: user-group-psp
spec:
  policyServer: default
  module: registry://ghcr.io/jvanz/policies/user-group-psp:latest
  rules:
  - apiGroups: [""]
    apiVersions: ["v1"]
    resources: ["pods"]
    operations:
    - CREATE
    - UPDATE
  mutating: true
  settings:
    run_as_user:
      rule: "MustRunAs"
      overwrite: true
      ranges:
        - min: 1000
          max: 2000
    run_as_group:
      rule: "RunAsAny"
    supplemental_groups:
      rule: "RunAsAny"
EOF
```

```bash
kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: pause-user-group
spec:
  containers:
    - name: pause
      image: k8s.gcr.io/pause
      securityContext:
        runAsUser: 3000
EOF
```

```bash
kubectl get pod pause-user-group -o json | jq ".spec.containers[].securityContext"                                             
{
  "runAsUser": 1000
}
```

```bash
kubectl delete clusteradmissionpolicy user-group-psp

kubectl apply -f  - <<EOF
apiVersion: policies.kubewarden.io/v1alpha2
kind: ClusterAdmissionPolicy
metadata:
  name: user-group-psp
spec:
  policyServer: default
  module: registry://ghcr.io/jvanz/policies/user-group-psp:latest
  rules:
  - apiGroups: [""]
    apiVersions: ["v1"]
    resources: ["pods"]
    operations:
    - CREATE
    - UPDATE
  mutating: true
  settings:
    run_as_user:
      rule: "MustRunAs"
      ranges:
        - min: 1000
          max: 2000
    run_as_group:
      rule: "RunAsAny"
    supplemental_groups:
      rule: "RunAsAny"
EOF
```

```bash
kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: pause-user-group
spec:
  containers:
    - name: pause
      image: k8s.gcr.io/pause
      securityContext:
        runAsUser: 1000
EOF
```