### PR TITLE
Verify securityContext from PodSpec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.1.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "user-group-psp"
-version = "0.1.5"
+version = "0.4.0"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ You can see more information about the setting in the following section.
 
 The policy has three settings:
 
-* `run_as_user`: Controls which user ID the containers are run with.
-* `run_as_group`:  Controls which primary group ID the containers are run with.
+* `run_as_user`: Controls which user ID the containers are run with. As well as the user in the securityContext from PodSpec.
+* `run_as_group`:  Controls which primary group ID the containers are run with. As well as the group in the securityContext from PodSpec.
 * `supplemental_groups`: Controls which group IDs containers add.
 
 All three settings have no defaults, just like the deprecated PSP (also, they would get used if `mutating` is `true`).

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.0
+version: 0.4.0
 name: user-group-psp
 displayName: User Group PSP
 createdAt: '2022-07-19T16:27:15+02:00'
@@ -8,7 +8,7 @@ license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.3.0
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.0
 keywords:
 - psp
 - container
@@ -16,7 +16,7 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.3.0/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 provider:

--- a/test_data/deployment_with_user.json
+++ b/test_data/deployment_with_user.json
@@ -1,0 +1,178 @@
+{
+  "dryRun": false,
+  "kind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "object": {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "annotations": {
+        "io.kubewarden.policy.echo.create": "true",
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":0,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:latest\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"securityContext\":{\"runAsUser\":0}}]}}}}\n"
+      },
+      "creationTimestamp": "2022-09-23T13:40:09Z",
+      "generation": 1,
+      "managedFields": [
+        {
+          "apiVersion": "apps/v1",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:io.kubewarden.policy.echo.create": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              }
+            },
+            "f:spec": {
+              "f:progressDeadlineSeconds": {},
+              "f:replicas": {},
+              "f:revisionHistoryLimit": {},
+              "f:selector": {},
+              "f:strategy": {
+                "f:rollingUpdate": {
+                  ".": {},
+                  "f:maxSurge": {},
+                  "f:maxUnavailable": {}
+                },
+                "f:type": {}
+              },
+              "f:template": {
+                "f:metadata": {
+                  "f:labels": {
+                    ".": {},
+                    "f:app": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"nginx\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {},
+                      "f:securityContext": {
+                        ".": {},
+                        "f:runAsUser": {}
+                      },
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            }
+          },
+          "manager": "kubectl-client-side-apply",
+          "operation": "Update",
+          "time": "2022-09-23T13:40:09Z"
+        }
+      ],
+      "name": "nginx",
+      "namespace": "default",
+      "uid": "84716ca0-aa8b-4b0c-a0ca-0ad7e0c4c9c6"
+    },
+    "spec": {
+      "progressDeadlineSeconds": 600,
+      "replicas": 0,
+      "revisionHistoryLimit": 10,
+      "selector": {
+        "matchLabels": {
+          "app": "nginx"
+        }
+      },
+      "strategy": {
+        "rollingUpdate": {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%"
+        },
+        "type": "RollingUpdate"
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "nginx"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx:latest",
+              "imagePullPolicy": "Always",
+              "name": "nginx",
+              "ports": [
+                {
+                  "containerPort": 80,
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {},
+              "securityContext": {
+                "runAsUser": 3000
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {
+            "runAsUser": 3000
+          },
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  "operation": "CREATE",
+  "options": {
+    "apiVersion": "meta.k8s.io/v1",
+    "fieldManager": "kubectl-client-side-apply",
+    "kind": "CreateOptions"
+  },
+  "requestKind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "requestResource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "uid": "8560a482-887d-49b2-8781-415d04a0dcb0",
+  "userInfo": {
+    "groups": [
+      "system:masters",
+      "system:authenticated"
+    ],
+    "username": "system:admin"
+  }
+}

--- a/test_data/pod_creation_must_run_as_with_group_id.json
+++ b/test_data/pod_creation_must_run_as_with_group_id.json
@@ -9,6 +9,9 @@
       "name": "nginx"
     },
     "spec": {
+      "securityContext": {
+        "runAsGroup": 1500
+      },
       "initContainers": [
         {
           "image": "nginx",

--- a/test_data/pod_creation_must_run_as_with_user_id.json
+++ b/test_data/pod_creation_must_run_as_with_user_id.json
@@ -9,6 +9,9 @@
       "name": "nginx"
     },
     "spec": {
+      "securityContext": {
+        "runAsUser": 1500
+      },
       "containers": [
         {
           "image": "nginx",


### PR DESCRIPTION
## Description
Updates the policy to perform the same verification done in the securityContext from the container in the securityContext from the PodSpec. This is necessary because the PodSpec security configuration is the fallback used if the containers do not have this settings.
    
Now, all the securityContext from the containers and the PodSpec should be in conformity with the policy settings in order to accept the request. As well as all the securityContext will be mutate if necessary.

Fix #36 
