### PR TITLE
fix: use correct metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "user-group-psp"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,14 +1,14 @@
 ---
-version: 0.4.1
+version: 0.4.2
 name: user-group-psp
 displayName: User Group PSP
-createdAt: '2023-01-19T13:27:15+02:00'
+createdAt: '2023-02-06T13:27:15+02:00'
 description: A Pod Security Policy that controls the container user and groups
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.1
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.2
 keywords:
 - psp
 - container
@@ -16,7 +16,7 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.1/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.2/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 provider:
@@ -31,8 +31,20 @@ annotations:
     rules:
     - apiGroups: [""]
       apiVersions: ["v1"]
-      resources: ["deployment","replicaset","statefulset","daemonset","replicationcontroller","job","cronjob","pod"]
-      operations: ["CREATE"]
+      resources: ["pods"]
+      operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["replicationcontrollers"]
+      operations: ["CREATE", "UPDATE"]
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments","replicasets","statefulsets","daemonsets"]
+      operations: ["CREATE", "UPDATE"]
+    - apiGroups: ["batch"]
+      apiVersions: ["v1"]
+      resources: ["jobs","cronjobs"]
+      operations: ["CREATE", "UPDATE"]
   kubewarden/questions-ui: |
     questions:
     - default: null

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,8 +1,20 @@
 rules:
-- apiGroups: [""]
-  apiVersions: ["v1"]
-  resources: ["deployment","replicaset","statefulset","daemonset","replicationcontroller","job","cronjob","pod"]
-  operations: ["CREATE"]
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["replicationcontrollers"]
+    operations: ["CREATE", "UPDATE"]
+  - apiGroups: ["apps"]
+    apiVersions: ["v1"]
+    resources: ["deployments","replicasets","statefulsets","daemonsets"]
+    operations: ["CREATE", "UPDATE"]
+  - apiGroups: ["batch"]
+    apiVersions: ["v1"]
+    resources: ["jobs","cronjobs"]
+    operations: ["CREATE", "UPDATE"]
 mutating: true
 contextAware: false
 executionMode: kubewarden-wapc


### PR DESCRIPTION
Tag a new release of the policy that has the right metadata for the
`rules` section.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
