### PR TITLE
chore: Bump version to 0.4.8 in cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "user-group-psp"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.4.7
+version: 0.4.8
 name: user-group-psp
 displayName: User Group PSP
-createdAt: 2023-03-24T16:15:45.076684829Z
+createdAt: 2023-05-16T10:53:49.214857091Z
 description: Kubewarden Policy that controls containers user and groups
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.7
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.8
 keywords:
 - psp
 - container
@@ -21,13 +21,13 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.7/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.8/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.4.7
+  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.4.8
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION

## Description

Release changes from https://github.com/kubewarden/user-group-psp-policy/pull/56


Run `make annotated-policy.wasm`, to refresh the Cargo.lock file. This also refreshes the artifacthub-pkg.yml file, for release on https://artifacthub.io.

## Test

By CI.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
