### PR TITLE
Bump v0.4.9 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "user-group-psp"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.4.8
+version: 0.4.9
 name: user-group-psp
 displayName: User Group PSP
-createdAt: 2023-05-16T10:53:49.214857091Z
+createdAt: 2023-07-07T16:35:17.282041339Z
 description: Kubewarden Policy that controls containers user and groups
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.8
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.9
 keywords:
 - psp
 - container
@@ -21,13 +21,13 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.8/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.9/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.4.8
+  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.4.9
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.4.9

Related to https://github.com/kubewarden/kubewarden-controller/issues/479