### PR TITLE
fix!: Don't mutate for `pod.spec.securityContext` if not needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "user-group-psp"
-version = "0.4.9"
+version = "0.5.0"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.4.9
+version: 0.5.0
 name: user-group-psp
 displayName: User Group PSP
-createdAt: 2023-10-16T07:25:37.7335952Z
+createdAt: 2024-01-22T13:52:15.26445171Z
 description: Kubewarden Policy that controls containers user and groups
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.4.9
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.5.0
 keywords:
 - psp
 - container
@@ -21,17 +21,17 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.4.9/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.5.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.4.9
+  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.5.0
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/user-group-psp:v0.4.9
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/user-group-psp:v0.5.0
   ```
 maintainers:
 - name: Kubewarden developers

--- a/e2e.bats
+++ b/e2e.bats
@@ -14,6 +14,14 @@
 	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
 	[ $(expr "$output" : '.*"message":"User ID outside defined ranges".*') -ne 0 ]
  }
+ 
+@test "MustRunAs should accept valid container user ID without mutating even if pod securityContext is invalid" {
+	run kwctl run  --request-path test_data/e2e/pod_user_150.json  --settings-path test_data/e2e/settings_must_run_as_100_200.json annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+	[ $(expr "$output" : '.*"patchType":"JSONPatch".*') -eq 0 ]
+ }
 
 @test "MustRunAs should reject invalid group ID" {
 	run kwctl run  --request-path test_data/e2e/invalid_group_id.json  --settings-path test_data/e2e/settings_must_run_as.json annotated-policy.wasm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1262,6 +1262,98 @@ mod tests {
     }
 
     #[test]
+    fn must_run_as_should_accept_when_valid_user_id_is_defined_and_wrong_podsecuritycontext(
+    ) -> Result<(), ()> {
+        let request_file =
+            "test_data/pod_creation_must_run_as_with_user_id_wrong_podsecuritycontext.json";
+        let tc = Testcase {
+            name: String::from("MustRunAs should not mutate request when valid user ID is defined"),
+            fixture_file: String::from(request_file),
+            expected_validation_result: true,
+            settings: Settings {
+                run_as_user: RuleStrategy {
+                    rule: Rule::MustRunAs,
+                    ranges: vec![IDRange {
+                        min: 1500,
+                        max: 2000,
+                    }],
+                    ..Default::default()
+                },
+                run_as_group: RuleStrategy {
+                    rule: Rule::RunAsAny,
+                    ranges: vec![],
+                    ..Default::default()
+                },
+                supplemental_groups: RuleStrategy {
+                    rule: Rule::RunAsAny,
+                    ranges: vec![],
+                    ..Default::default()
+                },
+            },
+        };
+
+        let res = tc.eval(validate).unwrap();
+        assert!(
+            res.mutated_object.is_none(),
+            "MustRunAs should not mutate request when valid user ID is defined"
+        );
+        assert!(
+            res.accepted,
+            "MustRunAs should accept request when valid user ID is defined"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn must_run_as_should_mutate_when_valid_user_id_is_defined_and_wrong_podsecuritycontext_and_overwrite(
+    ) -> Result<(), ()> {
+        let request_file =
+            "test_data/pod_creation_must_run_as_with_user_id_wrong_podsecuritycontext.json";
+        let tc = Testcase {
+            name: String::from("MustRunAs should not mutate request when valid user ID is defined"),
+            fixture_file: String::from(request_file),
+            expected_validation_result: true,
+            settings: Settings {
+                run_as_user: RuleStrategy {
+                    rule: Rule::MustRunAs,
+                    ranges: vec![IDRange {
+                        min: 1500,
+                        max: 2000,
+                    }],
+                    overwrite: true,
+                },
+                run_as_group: RuleStrategy {
+                    rule: Rule::RunAsAny,
+                    ranges: vec![],
+                    ..Default::default()
+                },
+                supplemental_groups: RuleStrategy {
+                    rule: Rule::RunAsAny,
+                    ranges: vec![],
+                    ..Default::default()
+                },
+            },
+        };
+
+        let res = tc.eval(validate).unwrap();
+        assert!(
+            res.mutated_object.is_some(),
+            "MustRunAs should mutate request"
+        );
+        let pod_securitycontext_json = jsonpath::select(
+            res.mutated_object.as_ref().unwrap(),
+            "$.spec.securityContext.runAsUser",
+        )
+        .unwrap();
+        assert_eq!(
+            pod_securitycontext_json,
+            vec![1500],
+            "MustRunAs should add the 'supplementalGroups' when it is not defined"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn run_as_any_should_not_mutate_pod() -> Result<(), ()> {
         let request_file = "test_data/pod_creation_run_as_any.json";
         let tc = Testcase {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1486,7 +1486,7 @@ mod tests {
     }
 
     #[test]
-    fn must_run_as_should_mutates_groups_if_overwrite_is_set() -> Result<(), ()> {
+    fn must_run_as_should_mutate_groups_if_overwrite_is_set() -> Result<(), ()> {
         let request_file = "test_data/pod_creation_must_run_as_with_group_id.json";
         let tc = Testcase {
             name: String::from("'MustRunAs' should mutate groups when overwrite is 'true'"),
@@ -1550,7 +1550,7 @@ mod tests {
     }
 
     #[test]
-    fn may_run_as_should_not_mutates_group_if_overwrite_is_set() -> Result<(), ()> {
+    fn may_run_as_should_not_mutate_group_if_overwrite_is_set() -> Result<(), ()> {
         let request_file = "test_data/pod_creation_must_run_as_with_group_id.json";
         let tc = Testcase {
             name: String::from("'MayRunAs' should mutate request when overwrite is 'true'"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1784,7 +1784,7 @@ mod tests {
     fn check_if_response_has_mutate_object_and_set_run_as_non_root(
         test_res: anyhow::Result<ValidationResponse>,
     ) -> Result<(), ()> {
-        assert!(!test_res.is_err(), "The validate function failed.");
+        assert!(test_res.is_ok(), "The validate function failed.");
         let res = test_res.unwrap();
         assert!(res.mutated_object.is_some(), "Request should be mutated");
         let run_as_non_root_json = jsonpath::select(
@@ -1989,7 +1989,7 @@ mod tests {
             },
         };
         let test_res = tc.eval(validate);
-        assert!(!test_res.is_err(), "The validate function failed.");
+        assert!(test_res.is_ok(), "The validate function failed.");
         let res = test_res.unwrap();
         assert!(res.mutated_object.is_some(), "Request should be mutated");
         let run_as_non_root_json = jsonpath::select(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -198,7 +198,7 @@ mod tests {
         for rule in allowed_rules_values {
             let settings = Settings {
                 run_as_user: RuleStrategy {
-                    rule: rule,
+                    rule,
                     ranges: vec![IDRange {
                         min: 1000,
                         max: 1010,
@@ -480,9 +480,9 @@ mod tests {
             ..Default::default()
         };
         let is_valid = rule_strategy.is_valid_id(999);
-        assert_eq!(is_valid, false);
+        assert!(!is_valid);
         let is_valid = rule_strategy.is_valid_id(2001);
-        assert_eq!(is_valid, false);
+        assert!(!is_valid);
 
         let rule_strategy = RuleStrategy {
             rule: Rule::MustRunAs,
@@ -499,9 +499,9 @@ mod tests {
             ..Default::default()
         };
         let is_valid = rule_strategy.is_valid_id(2001);
-        assert_eq!(is_valid, false);
+        assert!(!is_valid);
         let is_valid = rule_strategy.is_valid_id(499);
-        assert_eq!(is_valid, false);
+        assert!(!is_valid);
         let is_valid = rule_strategy.is_valid_id(999);
         assert!(is_valid);
         let is_valid = rule_strategy.is_valid_id(1501);

--- a/test_data/e2e/pod_user_150.json
+++ b/test_data/e2e/pod_user_150.json
@@ -1,0 +1,160 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "group": "",
+    "version": "v1",
+    "kind": "Pod"
+  },
+  "resource": {
+    "group": "",
+    "version": "v1",
+    "resource": "pods"
+  },
+  "requestKind": {
+    "group": "",
+    "version": "v1",
+    "kind": "Pod"
+  },
+  "requestResource": {
+    "group": "",
+    "version": "v1",
+    "resource": "pods"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "operation": "CREATE",
+  "userInfo": {
+    "username": "kubernetes-admin",
+    "groups": [
+      "system:masters",
+      "system:authenticated"
+    ]
+  },
+  "object": {
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "nginx",
+      "namespace": "default",
+      "uid": "04dc7a5e-e1f1-4e34-8d65-2c9337a43e64",
+      "creationTimestamp": "2020-11-12T15:18:36Z",
+      "labels": {
+        "env": "test"
+      },
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"env\":\"test\"},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"nginx\"}],\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"example-key\",\"operator\":\"Exists\"}]}}\n"
+      },
+      "managedFields": [
+        {
+          "manager": "kubectl",
+          "operation": "Update",
+          "apiVersion": "v1",
+          "time": "2020-11-12T15:18:36Z",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              },
+              "f:labels": {
+                ".": {},
+                "f:env": {}
+              }
+            },
+            "f:spec": {
+              "f:containers": {
+                "k:{\"name\":\"nginx\"}": {
+                  ".": {},
+                  "f:image": {},
+                  "f:imagePullPolicy": {},
+                  "f:name": {},
+                  "f:resources": {},
+                  "f:terminationMessagePath": {},
+                  "f:terminationMessagePolicy": {}
+                }
+              },
+              "f:dnsPolicy": {},
+              "f:enableServiceLinks": {},
+              "f:restartPolicy": {},
+              "f:schedulerName": {},
+              "f:securityContext": {},
+              "f:terminationGracePeriodSeconds": {},
+              "f:tolerations": {}
+            }
+          }
+        }
+      ]
+    },
+    "spec": {
+      "securityContext": {},
+      "volumes": [
+        {
+          "name": "default-token-pvpz7",
+          "secret": {
+            "secretName": "default-token-pvpz7"
+          }
+        }
+      ],
+      "containers": [
+        {
+          "name": "nginx",
+          "image": "nginx",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "name": "default-token-pvpz7",
+              "readOnly": true,
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+            }
+          ],
+          "securityContext": {
+            "runAsUser": 150
+          },
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "imagePullPolicy": "IfNotPresent"
+        }
+      ],
+      "restartPolicy": "Always",
+      "terminationGracePeriodSeconds": 30,
+      "dnsPolicy": "ClusterFirst",
+      "serviceAccountName": "default",
+      "serviceAccount": "default",
+      "schedulerName": "default-scheduler",
+      "tolerations": [
+        {
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+        },
+        {
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+        },
+        {
+          "key": "dedicated",
+          "operator": "Equal",
+          "value": "tenantA",
+          "effect": "NoSchedule"
+        }
+      ],
+      "priority": 0,
+      "enableServiceLinks": true,
+      "preemptionPolicy": "PreemptLowerPriority"
+    },
+    "status": {
+      "phase": "Pending",
+      "qosClass": "BestEffort"
+    }
+  },
+  "oldObject": null,
+  "dryRun": false,
+  "options": {
+    "kind": "CreateOptions",
+    "apiVersion": "meta.k8s.io/v1"
+  }
+}

--- a/test_data/e2e/settings_must_run_as_100_200.json
+++ b/test_data/e2e/settings_must_run_as_100_200.json
@@ -1,0 +1,17 @@
+{
+  "run_as_user": {
+    "rule": "MustRunAs",
+    "ranges": [
+      {
+        "min": 100,
+        "max": 200
+      }
+    ]
+  },
+  "run_as_group": {
+    "rule": "RunAsAny"
+  },
+  "supplemental_groups": {
+    "rule": "RunAsAny"
+  }
+}

--- a/test_data/pod_creation_must_run_as_with_user_id_wrong_podsecuritycontext.json
+++ b/test_data/pod_creation_must_run_as_with_user_id_wrong_podsecuritycontext.json
@@ -1,0 +1,45 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "Pod",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "securityContext": {
+        "runAsUser": 3
+      },
+      "containers": [
+        {
+          "image": "nginx",
+          "name": "nginx",
+          "securityContext": {
+            "runAsUser": 1500
+          }
+        }
+      ],
+      "initContainers": [
+        {
+          "image": "nginx",
+          "name": "nginx",
+          "securityContext": {
+            "runAsUser": 1500
+          }
+        }
+      ]
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Pod"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": ["system:authenticated"]
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/user-group-psp-policy/issues/63

We have:
- The `pod.spec.securityContext` for all the containers in the pods.
- Per container `pod.spec.container[*].securityContext`. This takes precedence over the former.

When pod.spec.container[*].securityContext are valid (hence take
precedence):
- pod.spec.securityContext should not be mutated if `overwrite` equals false.
- pod.spec.securityContext should be mutated if `overwrite` equals true.

This is consistent with PSP behavior, see https://github.com/kubewarden/user-group-psp-policy/issues/63#issuecomment-1903851068.

This means that when configured with mutating `false`, valid requests will
be accepted, and not incorrectly rejected because of unneeded
mutation.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added a unit test and an E2E test.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
