### PR TITLE
chore: v0.6.0 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "user-group-psp"
-version = "0.5.0"
-authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
+version = "0.6.0"
+authors = ["Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>", "José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.5.0
+version: 0.6.0
 name: user-group-psp
 displayName: User Group PSP
-createdAt: 2024-01-22T13:52:15.26445171Z
+createdAt: 2024-06-28T14:15:37.021117635Z
 description: Kubewarden Policy that controls containers user and groups
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.5.0
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.6.0
 keywords:
 - psp
 - container
@@ -21,17 +21,17 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.5.0/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.6.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.5.0
+  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.6.0
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/user-group-psp:v0.5.0
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/user-group-psp:v0.6.0
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Bumps the policy version to v0.6.0.

Fix #75 