### PR TITLE
fix(docs): warning about container image validation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "user-group-psp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "user-group-psp"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>", "José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ The policy has three settings:
 * `run_as_group`:  Controls which primary group ID the containers are run with. As well as the group in the securityContext from PodSpec.
 * `supplemental_groups`: Controls which group IDs containers add.
 * `validate_container_image_configuration`: A boolean value that allows the policy to validate the `USER` directive in the container image configuration. The default value is `false`.
+> [!WARNING]  
+> When container image validation is enabled, the policy performs a host
+> capability call to access the container image metadata stored in the
+> registry. This involves network access and can slow down the policy
+> evaluation in a cold execution when this data is not stored in the cache.
+> Therefore, the policy server can interrupt the evaluation if it takes too
+> long to complete. This is controlled by a configuration in the policy server.
+> If necessary,
+> [adjust](https://docs.kubewarden.io/reference/policy-evaluation-timeout#configuration)
+> to avoid the interruption of the policy evaluation.
+
 
 All three settings have no defaults, just like the deprecated PSP (also, they would get used if `mutating` is `true`).
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.6.0
+version: 0.6.1
 name: user-group-psp
 displayName: User Group PSP
-createdAt: 2024-06-28T14:15:37.021117635Z
+createdAt: 2024-07-30T14:15:58.546470533Z
 description: Kubewarden Policy that controls containers user and groups
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/user-group-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/user-group-psp:v0.6.0
+  image: ghcr.io/kubewarden/policies/user-group-psp:v0.6.1
 keywords:
 - psp
 - container
@@ -21,17 +21,17 @@ keywords:
 - group
 links:
 - name: policy
-  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.6.0/policy.wasm
+  url: https://github.com/kubewarden/user-group-psp-policy/releases/download/v0.6.1/policy.wasm
 - name: source
   url: https://github.com/kubewarden/user-group-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.6.0
+  kwctl pull ghcr.io/kubewarden/policies/user-group-psp:v0.6.1
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/user-group-psp:v0.6.0
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/user-group-psp:v0.6.1
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the README file warning users about the potential issue when they enable this feature. The policy can be interrupted by the policy server if the evaluation took too much time.

Related to #93 
