### PR TITLE
fix: RunAsAny should not validate container group.

### DIFF
--- a/e2e.bats
+++ b/e2e.bats
@@ -133,3 +133,10 @@
 	[ $(expr "$output" : '.*invalid type: integer `1`, expected a boolean.*') -ne 0 ]
 
  }
+
+@test "RunAsAny should accept when container image group validation is enabled" {
+	run kwctl run  --request-path test_data/e2e/invalid_container_image_user_id.json --settings-path test_data/e2e/settings_run_as_any_and_validate_container.json annotated-policy.wasm
+	[ "$status" -eq 0 ]
+	echo "$output"
+	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+ }

--- a/test_data/e2e/settings_run_as_any_and_validate_container.json
+++ b/test_data/e2e/settings_run_as_any_and_validate_container.json
@@ -1,0 +1,12 @@
+{
+  "validate_container_image_configuration" : true,
+  "run_as_user": {
+    "rule": "RunAsAny"
+  },
+  "run_as_group": {
+    "rule": "RunAsAny"
+  },
+  "supplemental_groups": {
+    "rule": "RunAsAny"
+  }
+}


### PR DESCRIPTION
## Description

When the policy is configure to allow any group. In other words, when the policy rule is "RunAsAny", but the container image validation is enabled, the policy is validating the container image and returning an error. This commit fixes this by performing the container image group validation only when the Rule is "MustRunAs" or "MayRunAs".

